### PR TITLE
link repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Zapoznaj się z [instrukcją](CONTRIBUTING.md) zgłaszania Pull Requestów.
 
 ## Spis Treści
 - **Kategorie**
-	- [C++](#c++)
+	- [C++](#c)
 	- [Back-end](#back-end)
 	- [Front-end](#front-end)
 	- [JAVA](#java)
-	- [C#](#CSharp)
+	- [C#](#csharp)
 	- [LINUX](#linux)
 	- [VCS](#vcs)
 	- [Inne](#inne)


### PR DESCRIPTION
Naprawa linków.
Uwaga na przyszłość - linki się ucinają, gdy piszemy takie coś "C++" to
jego linkiem jest."#c"
Jak zostanie wprowadzony język programowania C w linkach to trzeba się trochę pobawić,
jeszcze naprawiłem link C#'ba.
Teraz wszystko działa prawidłowo.
Pozdrawiam.
